### PR TITLE
fix golint

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-resty/resty/v2"
 )
 
+// next host interface
 type Client interface {
 	Post(hosts *Hosts) (*Hosts, error)
 }
@@ -16,6 +17,7 @@ type client struct {
 	client  *resty.Client
 }
 
+// create next host client
 func NewClient(nextAddress, nextPort string) Client {
 	return &client{
 		baseUrl: fmt.Sprintf("http://%s:%s", nextAddress, nextPort),
@@ -38,12 +40,16 @@ func (h *client) Post(hosts *Hosts) (*Hosts, error) {
 	return &response, nil
 }
 
+//  host info
 type Host struct {
 	HostName string `json:"host_name"`
 	To       string `json:"to,omitempty"`
 }
+
+// type host array
 type Hosts []Host
 
+// add current host info to Hosts
 func (r *Hosts) AddCurrentHostInfo(hostName string, nextHost string) *Hosts {
 	*r = append(*r, Host{HostName: hostName, To: nextHost})
 	return r

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
+// Configuration structure
 type Config struct {
 	HostName        string `envconfig:"HOSTNAME" required:"true"`
 	ListenPort      string `envconfig:"LISTEN_PORT" default:"8080"`
@@ -11,6 +12,7 @@ type Config struct {
 	NextHostPort    string `envconfig:"NEXT_HOST_PORT" default:"8080"`
 }
 
+// Mapping read environment variables to the Config structure
 func (c *Config) LoadConfig() error {
 
 	if err := envconfig.Process("", c); err != nil {

--- a/server/controllers/chain.go
+++ b/server/controllers/chain.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// chain host name controller
 func Chain(c *gin.Context) {
 	currentHost := c.MustGet("currentHost").(types.CurrentHost)
 

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -6,6 +6,7 @@ import (
 	"hostname-chainer/types"
 )
 
+// currentHost interface set to middleware
 func SetHostInfo(currentHost types.CurrentHost) gin.HandlerFunc {
 	return func(context *gin.Context) {
 		context.Set("currentHost", currentHost)

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -6,6 +6,7 @@ import (
 	"hostname-chainer/server/controllers"
 )
 
+// routing
 func Build(r *gin.Engine) {
 	r.
 		POST("/", controllers.Chain)

--- a/server/server.go
+++ b/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// start server
 func Run() error {
 
 	var conf config.Config

--- a/types/host.go
+++ b/types/host.go
@@ -4,6 +4,7 @@ import (
 	"hostname-chainer/config"
 )
 
+// host interface
 type CurrentHost interface {
 	GetHostName() string
 	GetNextHostAddress() string
@@ -17,6 +18,7 @@ type currentHostInfo struct {
 	nextHostAddress string
 }
 
+// create current host infomation struct from environment
 func NewHost(conf config.Config) CurrentHost {
 	return &currentHostInfo{
 		hostName:        conf.HostName,


### PR DESCRIPTION
golint12%
Golint is a linter for Go source code.

hostname-chainer/config/config.go
Line 7: warning: exported type Config should have comment or be unexported (golint)
Line 14: warning: exported method Config.LoadConfig should have comment or be unexported (golint)
hostname-chainer/server/server.go
Line 14: warning: exported function Run should have comment or be unexported (golint)
hostname-chainer/types/host.go
Line 7: warning: exported type CurrentHost should have comment or be unexported (golint)
Line 20: warning: exported function NewHost should have comment or be unexported (golint)
hostname-chainer/client/client.go
Line 10: warning: exported type Client should have comment or be unexported (golint)
Line 19: warning: exported function NewClient should have comment or be unexported (golint)
Line 41: warning: exported type Host should have comment or be unexported (golint)
Line 45: warning: exported type Hosts should have comment or be unexported (golint)
Line 47: warning: exported method Hosts.AddCurrentHostInfo should have comment or be unexported (golint)
hostname-chainer/server/controllers/chain.go
Line 12: warning: exported function Chain should have comment or be unexported (golint)
hostname-chainer/server/middleware/middleware.go
Line 9: warning: exported function SetHostInfo should have comment or be unexported (golint)
hostname-chainer/server/router/router.go
Line 9: warning: exported function Build should have comment or be unexported (golint)